### PR TITLE
add dependency serpent

### DIFF
--- a/config/software/pyro4.rb
+++ b/config/software/pyro4.rb
@@ -3,6 +3,7 @@ default_version "4.36"
 
 dependency "python"
 dependency "pip"
+dependency "serpent"
 
 build do
   ship_license "https://raw.githubusercontent.com/irmen/Pyro4/master/LICENSE"

--- a/config/software/serpent.rb
+++ b/config/software/serpent.rb
@@ -1,0 +1,12 @@
+name "serpent"
+default_version "1.28"
+
+dependency "python"
+dependency "pip"
+
+build do
+  ship_license "https://raw.githubusercontent.com/irmen/Serpent/master/LICENSE"
+  pip "install --install-option=\"--install-scripts="\
+      "#{windows_safe_path(install_dir)}/bin\" "\
+      "serpent==#{version}"
+end


### PR DESCRIPTION
Add serpent 1.28 version for PyRo4 as dependency to fix the test because PyRo4 4.36 version by default installs `serpent 1.30` which doesn't support python 2.x.